### PR TITLE
Add to client API the ability to open a connection forwarded to an endpoint in a precise network

### DIFF
--- a/api/httpresp/network.go
+++ b/api/httpresp/network.go
@@ -8,6 +8,10 @@ type NetworkCreate struct {
 	Network types.Network `json:"network"`
 }
 
+type NetworkShow struct {
+	Network types.Network `json:"network"`
+}
+
 type NetworksList struct {
 	Networks []types.Network `json:"networks"`
 }

--- a/api/params/network_connect.go
+++ b/api/params/network_connect.go
@@ -1,0 +1,6 @@
+package params
+
+type NetworkConnect struct {
+	IP   string `json:"ip"`
+	Port string `json:"port"`
+}

--- a/client/sand/client.go
+++ b/client/sand/client.go
@@ -2,6 +2,7 @@ package sand
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 type Client interface {
 	NetworksList(context.Context) ([]types.Network, error)
 	NetworkCreate(context.Context, params.NetworkCreate) (types.Network, error)
+	NetworkShow(context.Context, string) (types.Network, error)
+	NetworkConnect(context.Context, string, params.NetworkConnect) (net.Conn, error)
 	NetworkDelete(context.Context, string) error
 	EndpointCreate(context.Context, params.EndpointCreate) (types.Endpoint, error)
 	EndpointsList(context.Context, params.EndpointsList) ([]types.Endpoint, error)

--- a/client/sand/network.go
+++ b/client/sand/network.go
@@ -13,6 +13,27 @@ import (
 	"github.com/pkg/errors"
 )
 
+func (c *client) NetworkShow(ctx context.Context, id string) (types.Network, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/networks/%s", c.url, id), nil)
+	if err != nil {
+		return types.Network{}, errors.Wrapf(err, "fail to create http request")
+	}
+	req = req.WithContext(ctx)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return types.Network{}, errors.Wrapf(err, "fail to execute GET /networks/%s", id)
+	}
+	defer res.Body.Close()
+
+	var r httpresp.NetworkShow
+	err = json.NewDecoder(res.Body).Decode(&r)
+	if err != nil {
+		return types.Network{}, errors.Wrapf(err, "fail to unserialize JSON")
+	}
+
+	return r.Network, nil
+}
+
 func (c *client) NetworksList(ctx context.Context) ([]types.Network, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/networks", c.url), nil)
 	if err != nil {

--- a/client/sand/network_connect.go
+++ b/client/sand/network_connect.go
@@ -1,0 +1,54 @@
+package sand
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/Scalingo/sand/api/params"
+	"github.com/pkg/errors"
+)
+
+func (c *client) NetworkConnect(ctx context.Context, id string, opts params.NetworkConnect) (net.Conn, error) {
+	req, err := http.NewRequest("CONNECT", fmt.Sprintf("%s/networks/%s?ip=%s&port=%s", c.url, id, opts.IP, opts.Port), nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to create http request")
+	}
+	req = req.WithContext(ctx)
+
+	url, err := url.Parse(c.url)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to parse URL", c.url)
+	}
+	dial, err := net.Dial("tcp", url.Host)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to connect to %s", url.Host)
+	}
+
+	var conn *httputil.ClientConn
+	if url.Scheme == "https" {
+		host := strings.Split(url.Host, ":")[0]
+		config := *c.tlsConfig
+		config.ServerName = host
+		tls_conn := tls.Client(dial, &config)
+		conn = httputil.NewClientConn(tls_conn, nil)
+	} else {
+		conn = httputil.NewClientConn(dial, nil)
+	}
+
+	res, err := conn.Do(req)
+	if err != httputil.ErrPersistEOF && err != nil {
+		return nil, errors.Wrapf(err, "fail to execute CONNECT /networks/%s", id)
+	}
+	if res.StatusCode != 200 {
+		return nil, errors.Errorf("invalid return code %v", res.StatusCode)
+	}
+
+	socket, _ := conn.Hijack()
+	return socket, nil
+}

--- a/client/sandenter/net.go
+++ b/client/sandenter/net.go
@@ -1,0 +1,31 @@
+package sandenter
+
+import (
+	"context"
+	"net"
+
+	"github.com/Scalingo/sand/client/sand"
+	"github.com/pkg/errors"
+)
+
+type handle struct {
+	client sand.Client
+	nid    string
+}
+
+func NewHandle(client sand.Client, networkID string) handle {
+	return handle{client: client, nid: networkID}
+}
+
+func (h handle) Dial(ctx context.Context) func(proto, dest string) (net.Conn, error) {
+	return func(proto, dest string) (net.Conn, error) {
+		network, err := h.client.NetworksShow(ctx, h.nid)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fail to get network")
+		}
+
+		func
+		network.NSHandlePath
+		return nil, nil
+	}
+}

--- a/cmd/sand-agent-cli/main.go
+++ b/cmd/sand-agent-cli/main.go
@@ -55,6 +55,14 @@ func main() {
 				cli.StringFlag{Name: "network,n", Usage: "ID of the network to delete"},
 			},
 		}, {
+			Name:   "network-connect",
+			Action: app.NetworkConnect,
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "network,n", Usage: "ID of the network to connect to"},
+				cli.StringFlag{Name: "ip", Usage: "IP to reach in the network"},
+				cli.StringFlag{Name: "port", Usage: "Port to reach in the network"},
+			},
+		}, {
 			Name:   "endpoint-list",
 			Action: app.EndpointsList,
 			Flags: []cli.Flag{

--- a/cmd/sand-agent-cli/network_connect.go
+++ b/cmd/sand-agent-cli/network_connect.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/Scalingo/go-utils/logger"
+	"github.com/Scalingo/sand/api/params"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+func (a *App) NetworkConnect(c *cli.Context) error {
+	log := logger.Default()
+
+	client, err := a.sandClient(c)
+	if err != nil {
+		return err
+	}
+
+	if c.String("network") == "" {
+		return errors.New("--network flag is mandatory")
+	}
+
+	conn, err := client.NetworkConnect(context.Background(), c.String("network"), params.NetworkConnect{
+		IP:   c.String("ip"),
+		Port: c.String("port"),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "fail to connect to network %v", c.String("network"))
+	}
+
+	listener, err := net.Listen("tcp", ":")
+	if err != nil {
+		return errors.Wrapf(err, "fail to bind a socket")
+	}
+	defer listener.Close()
+
+	log.Infof("Waiting connection on %v", listener.Addr())
+
+	localConn, err := listener.Accept()
+	if err != nil {
+		return errors.Wrapf(err, "fail to accept connection")
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		defer conn.Close()
+		_, err := io.Copy(localConn, conn)
+		if err != io.EOF && err != nil {
+			log.WithError(err).Error("fail to copy data from remote network to local socket")
+		}
+		log.Info("remote network connection closed")
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer localConn.Close()
+		_, err := io.Copy(conn, localConn)
+		if err != io.EOF && err != nil {
+			log.WithError(err).Error("fail to copy data from remote network to local socket")
+		}
+		log.Infof("local connection on %v closed", listener.Addr())
+	}()
+
+	wg.Wait()
+	return nil
+}

--- a/cmd/sand-agent/sand-agent.go
+++ b/cmd/sand-agent/sand-agent.go
@@ -94,7 +94,9 @@ func main() {
 	r.Use(handlers.ErrorMiddleware)
 	r.HandleFunc("/networks", nctrl.List).Methods("GET")
 	r.HandleFunc("/networks", nctrl.Create).Methods("POST")
+	r.HandleFunc("/networks/{id}", nctrl.Show).Methods("GET")
 	r.HandleFunc("/networks/{id}", nctrl.Destroy).Methods("DELETE")
+	r.HandleFunc("/networks/{id}", nctrl.Connect).Methods("CONNECT")
 	r.HandleFunc("/endpoints", ectrl.Create).Methods("POST")
 	r.HandleFunc("/endpoints", ectrl.List).Methods("GET")
 	r.HandleFunc("/endpoints/{id}", ectrl.Destroy).Methods("DELETE")
@@ -233,6 +235,8 @@ func ensureNetworks(ctx context.Context, c *config.Config, repo network.Reposito
 
 		endpoint, err = erepo.Activate(ctx, network, endpoint, params.EndpointActivate{
 			NSHandlePath: endpoint.TargetNetnsPath,
+			SetAddr:      true,
+			MoveVeth:     true,
 		})
 		if err != nil {
 			log.WithError(err).Error("fail to ensure endpoint")

--- a/netnsbuilder/init.go
+++ b/netnsbuilder/init.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	reexec.Register("sc-netns-create", reexecCreateNamespace)
+	reexec.Register("sc-netns-pipe-socket", pipeSocket)
 }
 
 func reexecCreateNamespace() {

--- a/netnsbuilder/socket.go
+++ b/netnsbuilder/socket.go
@@ -1,0 +1,78 @@
+package netnsbuilder
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/Scalingo/go-utils/logger"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netns"
+)
+
+func pipeSocket() {
+	if len(os.Args) != 4 {
+		logrus.Fatalf("%s <ns handle> <ip> <port>", os.Args[0])
+	}
+	log := logger.Default().WithFields(logrus.Fields{"ns": os.Args[1], "ip": os.Args[2], "port": os.Args[3]})
+	log.Info("piping socket")
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	file := os.NewFile(3, "socket")
+	conn, err := net.FileConn(file)
+	if err != nil {
+		log.WithError(err).Error("fail to get connection from opened file descriptor")
+		os.Exit(1)
+	}
+	tcpConn := conn.(*net.TCPConn)
+
+	nsfd, err := netns.GetFromPath(os.Args[1])
+	if err != nil {
+		log.WithError(err).Error("fail to get network namespace handler")
+		os.Exit(-1)
+	}
+
+	err = netns.Set(nsfd)
+	if err != nil {
+		log.WithError(err).Error("fail to set namespace")
+		os.Exit(-1)
+	}
+
+	socket, err := net.Dial("tcp", fmt.Sprintf("%s:%s", os.Args[2], os.Args[3]))
+	if err != nil {
+		tcpConn.Close()
+		log.WithError(err).Error("Fail to open TCP connection")
+		os.Exit(-1)
+	}
+	tcpSocket := socket.(*net.TCPConn)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer tcpConn.Close()
+		defer tcpSocket.CloseWrite()
+		_, err := io.Copy(tcpSocket, tcpConn)
+		if err != nil && err != io.EOF {
+			log.WithError(err).Error("fail to copy stdin to socket")
+		}
+		log.Info("connection from file descriptor closed")
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer tcpSocket.Close()
+		defer tcpConn.CloseWrite()
+		_, err := io.Copy(tcpConn, tcpSocket)
+		if err != nil && err != io.EOF {
+			log.WithError(err).Error("fail to copy socket to stdout")
+		}
+		log.Info("connection from ns socket closed")
+	}()
+	wg.Wait()
+}

--- a/web/networks_controller_connect.go
+++ b/web/networks_controller_connect.go
@@ -1,0 +1,60 @@
+package web
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/Scalingo/go-internal-tools/logger"
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/pkg/errors"
+)
+
+func (c NetworksController) Connect(w http.ResponseWriter, r *http.Request, params map[string]string) error {
+	w.Header().Set("Content-Type", "application/json")
+	ctx := r.Context()
+	log := logger.Get(ctx).WithField("network_id", params["id"])
+
+	network, ok, err := c.NetworkRepository.Exists(ctx, params["id"])
+	if err != nil {
+		return errors.Wrapf(err, "fail to query store")
+	} else if !ok {
+		w.WriteHeader(404)
+		return errors.New("network not found")
+	}
+
+	log.Info("hijacking http connection")
+	h := w.(http.Hijacker)
+	socket, _, err := h.Hijack()
+	if err != nil {
+		return errors.Wrapf(err, "fail to hijack http connection")
+	}
+
+	fmt.Fprintf(socket, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n")
+
+	ip := r.URL.Query().Get("ip")
+	port := r.URL.Query().Get("port")
+
+	tcpSocket := socket.(*net.TCPConn)
+	socketFile, err := tcpSocket.File()
+	if err != nil {
+		return errors.Wrapf(err, "fail to get file from tcp connection")
+	}
+
+	cmd := &exec.Cmd{
+		Path:       reexec.Self(),
+		Args:       append([]string{"sc-netns-pipe-socket"}, network.NSHandlePath, ip, port),
+		Stderr:     os.Stderr,
+		Stdout:     os.Stdout,
+		ExtraFiles: []*os.File{socketFile},
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "fail to pipe socket to %s %s:%s", network.NSHandlePath, ip, port)
+	}
+
+	return nil
+}

--- a/web/networks_controller_show.go
+++ b/web/networks_controller_show.go
@@ -1,0 +1,34 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Scalingo/go-internal-tools/logger"
+	"github.com/Scalingo/sand/api/httpresp"
+	"github.com/pkg/errors"
+)
+
+func (c NetworksController) Show(w http.ResponseWriter, r *http.Request, params map[string]string) error {
+	w.Header().Set("Content-Type", "application/json")
+	ctx := r.Context()
+	log := logger.Get(ctx)
+
+	network, ok, err := c.NetworkRepository.Exists(ctx, params["id"])
+	if err != nil {
+		return errors.Wrapf(err, "fail to query store")
+	} else if !ok {
+		w.WriteHeader(404)
+		return errors.New("network not found")
+	}
+	res := httpresp.NetworkShow{
+		Network: network,
+	}
+
+	w.WriteHeader(200)
+	err = json.NewEncoder(w).Encode(&res)
+	if err != nil {
+		log.WithError(err).Error("fail to encode JSON")
+	}
+	return nil
+}


### PR DESCRIPTION
This is not 100% done, it requires a little more testing.

A focus can be made on the piping on the connection to be sure that when a connection is
closed, it's forwarded to the other end of the pipe, in both sides.