### PR TITLE
Add a 'recursive' flag for network-delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+sand-agent-cli
 .vagrant
 docker/
 /sand-agent

--- a/cmd/sand-agent-cli/main.go
+++ b/cmd/sand-agent-cli/main.go
@@ -59,6 +59,7 @@ func main() {
 			Action: app.NetworkDelete,
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "network,n", Usage: "ID of the network to delete"},
+				cli.BoolFlag{Name: "recursive,r", Usage: "Also delete the endpoints"},
 			},
 		}, {
 			Name:   "network-connect",

--- a/cmd/sand-agent-cli/network.go
+++ b/cmd/sand-agent-cli/network.go
@@ -79,6 +79,7 @@ func (a *App) NetworkDelete(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
+			fmt.Printf("Endpoint '%s' deleted.\n", endpoint.ID)
 		}
 	}
 

--- a/cmd/sand-agent-cli/network.go
+++ b/cmd/sand-agent-cli/network.go
@@ -61,12 +61,28 @@ func (a *App) NetworksList(c *cli.Context) error {
 }
 
 func (a *App) NetworkDelete(c *cli.Context) error {
+	ctx := context.Background()
 	client, err := a.sandClient(c)
 	if err != nil {
 		return err
 	}
 
-	err = client.NetworkDelete(context.Background(), c.String("network"))
+	if c.Bool("recursive") {
+		endpoints, err := client.EndpointsList(ctx, params.EndpointsList{
+			NetworkID: c.String("network"),
+		})
+		if err != nil {
+			return err
+		}
+		for _, endpoint := range endpoints {
+			err := client.EndpointDelete(ctx, endpoint.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err = client.NetworkDelete(ctx, c.String("network"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I chose `--recursive` instead of `-f` as indicated by the issue #15 as it seems more relevant.

Fix #15