### PR TITLE
Fix listing of endpoint in case hostname is prefix of another hostname

### DIFF
--- a/endpoint/list.go
+++ b/endpoint/list.go
@@ -18,11 +18,11 @@ func (r *repository) List(ctx context.Context, filters map[string]string) ([]typ
 
 	if networkID == "" {
 		// if hostname empty -> all the endpoints
-		key = fmt.Sprintf("%s/%s", types.EndpointStoragePrefix, hostname)
+		key = fmt.Sprintf("%s/%s/", types.EndpointStoragePrefix, hostname)
 	} else if networkID != "" && hostname == "" {
-		key = fmt.Sprintf("%s/%s", types.NetworkEndpointStoragePrefix, networkID)
+		key = fmt.Sprintf("%s/%s/", types.NetworkEndpointStoragePrefix, networkID)
 	} else {
-		key = fmt.Sprintf("%s/%s/%s", types.EndpointStoragePrefix, r.config.PublicHostname, networkID)
+		key = fmt.Sprintf("%s/%s/%s/", types.EndpointStoragePrefix, r.config.PublicHostname, networkID)
 	}
 
 	err := r.store.Get(ctx, key, true, &endpoints)


### PR DESCRIPTION
We got the following case, one node was ip-10-0-0-207 and another ip-10-0-0-20

When ip-10-0-0-20 was starting, it ensured all networks from ip-10-0-0-207 because of the prefix

This commit aims at preventing this
This commit aims at preventing this