### PR TITLE
Fix etcd config in dev environment

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -12,7 +12,7 @@ import (
 func NewClient() (*clientv3.Client, error) {
 	// Error has already been checked in the config initialization. We can safely ignore it here
 	etcdConfig, _ := etcdutils.ConfigFromEnv()
-	if os.Getenv("GO_ENV") == "development" {
+	if os.Getenv("GO_ENV") == "development" && etcdConfig.TLS != nil {
 		etcdConfig.TLS.InsecureSkipVerify = true
 	}
 


### PR DESCRIPTION
```
web_1   | [00] panic: runtime error: invalid memory address or nil pointer dereference
web_1   | [00] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd378df]
web_1   | [00] 
web_1   | [00] goroutine 1 [running]:
web_1   | [00] github.com/Scalingo/sand/etcd.NewClient(0xc0001f3e10, 0xfeb96c, 0x7)
web_1   | [00]  /go/src/github.com/Scalingo/sand/etcd/client.go:16 +0x1ef
web_1   | [00] main.main()
web_1   | [00]  /go/src/github.com/Scalingo/sand/cmd/sand-agent/sand-agent.go:70 +0x61b
web_1   | [00] (error exit: exit status 2)
```