### PR TITLE
fix(error-mgmt) #39 Add no route to host into ignored errors when forwarding traffic, SAND is not responsible to check if the destination address is up or not

### DIFF
--- a/cmd/sand-agent-cli/network_connect.go
+++ b/cmd/sand-agent-cli/network_connect.go
@@ -46,6 +46,7 @@ func (a *App) NetworkConnect(c *cli.Context) error {
 			})
 			if err != nil {
 				log.WithError(err).Errorf("fail to connect to network %v", c.String("network"))
+				return
 			}
 
 			wg := &sync.WaitGroup{}

--- a/netutils/forward.go
+++ b/netutils/forward.go
@@ -8,9 +8,10 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/Scalingo/go-utils/logger"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netns"
+
+	"github.com/Scalingo/go-utils/logger"
 )
 
 type Conn interface {
@@ -50,10 +51,12 @@ func ForwardConnection(ctx context.Context, srcSocket net.Conn, ns, ip, port str
 	}()
 
 	dstHost := fmt.Sprintf("%s:%s", ip, port)
-	dstSocket, err := net.Dial("tcp", dstHost)
+	dialer := net.Dialer{}
+	dstSocket, err := dialer.DialContext(ctx, "tcp", dstHost)
 	if err != nil {
 		return errors.Wrapf(err, "fail to open connection to %v", dstHost)
 	}
+	fmt.Println("Connected to", dstHost)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)

--- a/netutils/forward.go
+++ b/netutils/forward.go
@@ -56,7 +56,6 @@ func ForwardConnection(ctx context.Context, srcSocket net.Conn, ns, ip, port str
 	if err != nil {
 		return errors.Wrapf(err, "fail to open connection to %v", dstHost)
 	}
-	fmt.Println("Connected to", dstHost)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)

--- a/web/networks_controller_connect.go
+++ b/web/networks_controller_connect.go
@@ -69,7 +69,7 @@ func (c NetworksController) Connect(w http.ResponseWriter, r *http.Request, urlp
 		return nil
 	}
 
-	log.Info("hijacking http connection and forward to %v", localEndpoint.Hostname)
+	log.Infof("hijacking http connection and forward to %v", localEndpoint.Hostname)
 	h := w.(http.Hijacker)
 	socket, _, err := h.Hijack()
 	if err != nil {


### PR DESCRIPTION
Fixes #39

Related to https://rollbar.com/Scalingo/sand/items/168/