### PR TITLE
fix(goreleaser): disable CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     binary: sand-agent
     main: ./cmd/sand-agent
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goarch:
       - 386
       - amd64
@@ -29,21 +29,21 @@ builds:
 archives:
   - format: tar.gz
     builds:
-    - sand-agent
-    - sand-agent-cli
+      - sand-agent
+      - sand-agent-cli
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
     files:
-    - LICENSE
-    - README.md
-    - CHANGELOG.md
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
I must say I don't really understand the reason why it has been explicitely _enabled_. There is no information in the commit which introduced this (d427b0113496c7342bc6b1ffcc585833a8ad141e). Anyway it seems safer to disable CGO. Cf. https://github.com/Scalingo/appsdeck-kitchen/issues/2313 for the reason why we need to disable CGO.