### PR TITLE
build(dev): disable CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ RUN go install github.com/cespare/reflex@latest
 ADD . /go/src/github.com/Scalingo/sand
 WORKDIR /go/src/github.com/Scalingo/sand
 EXPOSE 9999
+ENV CGO_ENABLED=0
 RUN go install -buildvcs=false github.com/Scalingo/sand/cmd/...
 CMD /go/bin/sand

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   web:
     build: .


### PR DESCRIPTION
Following #278, to have the same binary both in dev and in prod