### PR TITLE
Fix overlay neighbor replay for inactive endpoints

### DIFF
--- a/network/overlay/listener_test.go
+++ b/network/overlay/listener_test.go
@@ -1,12 +1,11 @@
 package overlay
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
-	clientv3 "go.etcd.io/etcd/client/v3"
+	etcdv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +31,7 @@ func TestListener_Add(t *testing.T) {
 			Name:       "it should start listening to message and stop when there is no more message",
 			ExpectDone: true,
 			ExpectRegistration: func(r *storemock.MockRegistration) {
-				c := make(chan *clientv3.Event)
+				c := make(chan *etcdv3.Event)
 				close(c)
 				r.EXPECT().EventChan().Return(c)
 			},
@@ -40,12 +39,13 @@ func TestListener_Add(t *testing.T) {
 			Name:       "it should handle PUT message with an Endpoint and add it as neighbor",
 			ExpectDone: true,
 			ExpectRegistration: func(r *storemock.MockRegistration) {
-				c := make(chan *clientv3.Event, 1)
-				c <- &clientv3.Event{
+				c := make(chan *etcdv3.Event, 1)
+				c <- &etcdv3.Event{
 					Type: mvccpb.PUT,
 					Kv: &mvccpb.KeyValue{
 						Value: []byte(`{
 							"id": "1",
+							"active": true,
 							"target_veth_ip": "10.0.0.1",
 							"hostname": "src-node.example.com"
 						}`),
@@ -56,7 +56,31 @@ func TestListener_Add(t *testing.T) {
 			},
 			ExpectNetManager: func(m *netmanagermock.MockNetManager, n types.Network) {
 				m.EXPECT().AddEndpointNeigh(gomock.Any(), n, types.Endpoint{
-					ID: "1", TargetVethIP: "10.0.0.1", Hostname: "src-node.example.com",
+					ID: "1", Active: true, TargetVethIP: "10.0.0.1", Hostname: "src-node.example.com",
+				}).Return(nil)
+			},
+		}, {
+			Name:       "it should forward PUT message with an inactive endpoint to neighbor manager",
+			ExpectDone: true,
+			ExpectRegistration: func(r *storemock.MockRegistration) {
+				c := make(chan *etcdv3.Event, 1)
+				c <- &etcdv3.Event{
+					Type: mvccpb.PUT,
+					Kv: &mvccpb.KeyValue{
+						Value: []byte(`{
+							"id": "1",
+							"active": false,
+							"target_veth_ip": "10.0.0.1",
+							"hostname": "src-node.example.com"
+						}`),
+					},
+				}
+				close(c)
+				r.EXPECT().EventChan().Return(c)
+			},
+			ExpectNetManager: func(m *netmanagermock.MockNetManager, n types.Network) {
+				m.EXPECT().AddEndpointNeigh(gomock.Any(), n, types.Endpoint{
+					ID: "1", Active: false, TargetVethIP: "10.0.0.1", Hostname: "src-node.example.com",
 				}).Return(nil)
 			},
 		},
@@ -76,7 +100,7 @@ func TestListener_Add(t *testing.T) {
 			network := types.Network{ID: "1"}
 			registrar.EXPECT().Register("/network-endpoints/1").Return(registration, nil)
 
-			listener := NewNetworkEndpointListener(context.Background(), config, registrar, store)
+			listener := NewNetworkEndpointListener(t.Context(), config, registrar, store)
 
 			if c.ExpectStore != nil {
 				c.ExpectStore(store, network, registrar)
@@ -90,7 +114,7 @@ func TestListener_Add(t *testing.T) {
 				c.ExpectNetManager(nm, network)
 			}
 
-			done, err := listener.Add(context.Background(), nm, network)
+			done, err := listener.Add(t.Context(), nm, network)
 			if c.Error != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), c.Error)

--- a/network/overlay/neigh.go
+++ b/network/overlay/neigh.go
@@ -16,15 +16,11 @@ import (
 
 func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network, endpoints []types.Endpoint) error {
 	for _, endpoint := range endpoints {
-		ctx, log := logger.WithFieldsToCtx(ctx, logrus.Fields{
+		ctx, _ = logger.WithFieldsToCtx(ctx, logrus.Fields{
 			"endpoint_id":              endpoint.ID,
 			"endpoint_target_ip":       endpoint.TargetVethIP,
 			"endpoint_target_hostname": endpoint.Hostname,
 		})
-		if !shouldReplayEndpointNeigh(endpoint) {
-			log.Info("skip inactive endpoint ARP/FDB replay")
-			continue
-		}
 
 		err := m.AddEndpointNeigh(ctx, network, endpoint)
 		if err != nil {
@@ -36,8 +32,8 @@ func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network
 
 func (m manager) AddEndpointNeigh(ctx context.Context, network types.Network, endpoint types.Endpoint) error {
 	ctx, log := logger.WithFieldToCtx(ctx, "neighbor_action", "add")
-	if !shouldReplayEndpointNeigh(endpoint) {
-		log.Info("skip inactive endpoint ARP/FDB replay")
+	if !endpoint.Active {
+		log.Info("Skip inactive endpoint ARP/FDB replay")
 		return nil
 	}
 
@@ -113,6 +109,3 @@ func (m manager) endpointNeighAction(ctx context.Context, network types.Network,
 	return nil
 }
 
-func shouldReplayEndpointNeigh(endpoint types.Endpoint) bool {
-	return endpoint.Active
-}

--- a/network/overlay/neigh.go
+++ b/network/overlay/neigh.go
@@ -15,14 +15,17 @@ import (
 )
 
 func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network, endpoints []types.Endpoint) error {
-	log := logger.Get(ctx)
 	for _, endpoint := range endpoints {
-		log = log.WithFields(logrus.Fields{
+		ctx, log := logger.WithFieldsToCtx(ctx, logrus.Fields{
 			"endpoint_id":              endpoint.ID,
 			"endpoint_target_ip":       endpoint.TargetVethIP,
 			"endpoint_target_hostname": endpoint.Hostname,
 		})
-		ctx = logger.ToCtx(ctx, log)
+		if !shouldReplayEndpointNeigh(endpoint) {
+			log.Info("skip inactive endpoint ARP/FDB replay")
+			continue
+		}
+
 		err := m.AddEndpointNeigh(ctx, network, endpoint)
 		if err != nil {
 			return errors.Wrapf(err, "fail to add endpoint ARP/FDB neigh rules")
@@ -32,7 +35,12 @@ func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network
 }
 
 func (m manager) AddEndpointNeigh(ctx context.Context, network types.Network, endpoint types.Endpoint) error {
-	ctx = logger.ToCtx(ctx, logger.Get(ctx).WithField("neighbor_action", "add"))
+	ctx, log := logger.WithFieldToCtx(ctx, "neighbor_action", "add")
+	if !shouldReplayEndpointNeigh(endpoint) {
+		log.Info("skip inactive endpoint ARP/FDB replay")
+		return nil
+	}
+
 	return m.endpointNeighAction(ctx, network, endpoint, (*netlink.Handle).NeighSet)
 }
 
@@ -103,4 +111,8 @@ func (m manager) endpointNeighAction(ctx context.Context, network types.Network,
 		return errors.Wrapf(err, "could not modify neighbor entry: %+v", nlnh)
 	}
 	return nil
+}
+
+func shouldReplayEndpointNeigh(endpoint types.Endpoint) bool {
+	return endpoint.Active
 }

--- a/network/overlay/neigh.go
+++ b/network/overlay/neigh.go
@@ -16,12 +16,6 @@ import (
 
 func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network, endpoints []types.Endpoint) error {
 	for _, endpoint := range endpoints {
-		ctx, _ = logger.WithFieldsToCtx(ctx, logrus.Fields{
-			"endpoint_id":              endpoint.ID,
-			"endpoint_target_ip":       endpoint.TargetVethIP,
-			"endpoint_target_hostname": endpoint.Hostname,
-		})
-
 		err := m.AddEndpointNeigh(ctx, network, endpoint)
 		if err != nil {
 			return errors.Wrapf(err, "fail to add endpoint ARP/FDB neigh rules")
@@ -31,7 +25,12 @@ func (m manager) EnsureEndpointsNeigh(ctx context.Context, network types.Network
 }
 
 func (m manager) AddEndpointNeigh(ctx context.Context, network types.Network, endpoint types.Endpoint) error {
-	ctx, log := logger.WithFieldToCtx(ctx, "neighbor_action", "add")
+	ctx, log := logger.WithFieldsToCtx(ctx, logrus.Fields{
+		"neighbor_action":          "add",
+		"endpoint_id":              endpoint.ID,
+		"endpoint_target_ip":       endpoint.TargetVethIP,
+		"endpoint_target_hostname": endpoint.Hostname,
+	})
 	if !endpoint.Active {
 		log.Info("Skip inactive endpoint ARP/FDB replay")
 		return nil
@@ -108,4 +107,3 @@ func (m manager) endpointNeighAction(ctx context.Context, network types.Network,
 	}
 	return nil
 }
-

--- a/network/overlay/neigh_test.go
+++ b/network/overlay/neigh_test.go
@@ -1,0 +1,33 @@
+package overlay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Scalingo/sand/api/types"
+	"github.com/Scalingo/sand/config"
+)
+
+func TestManager_EnsureEndpointsNeigh_IgnoresInactiveEndpoints(t *testing.T) {
+	m := manager{
+		config: &config.Config{PeerIP: "192.0.2.10"},
+	}
+
+	err := m.EnsureEndpointsNeigh(t.Context(), types.Network{NSHandlePath: "/does/not/exist"}, []types.Endpoint{
+		{
+			ID:           "active-endpoint",
+			Active:       true,
+			HostIP:       "192.0.2.10",
+			TargetVethIP: "10.0.0.5/24",
+		},
+		{
+			ID:           "inactive-endpoint",
+			Active:       false,
+			HostIP:       "192.0.2.20",
+			TargetVethIP: "10.0.0.5/24",
+		},
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- skip overlay neighbor replay for inactive endpoints during ensure/reconciliation
- ignore inactive endpoint PUT events in the overlay listener
- add regression coverage for active and inactive endpoints sharing the same target IP

Closes #321