### PR TITLE
Bump v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+## v1.2.0 - 25 Aug 2026
+
 * chore: use go-utils/errors for errors, make them not start by 'fail to', contextify everywhere for the errors
 * feat(ensure-networks): Add API endpoint and CLI command to trigger it manually without restartng the service (19 minutes ago)
 * feat(control-loop/ensure-networks): Add notion of control loop, ensure every 30 minutes (34 minutes ago)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SAND Network Daemon V1.1.5
+# SAND Network Daemon V1.2.0
 
 SAND is simple API designed to create overlay networks based on
 **[VXLAN](https://en.wikipedia.org/wiki/Virtual_Extensible_LAN)** in an infrastructure, basing its
@@ -237,7 +237,7 @@ Bump new version number in:
 Commit the new version number:
 
 ```sh
-version="1.1.5"
+version="1.2.0"
 
 sed --in-place "s/var Version = \"v\([0-9.]*\)\"/var Version = \"v$version\"/g" config/config.go
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-var Version = "v1.1.5"
+var Version = "v1.2.0"
 
 type Config struct {
 	RollbarToken string


### PR DESCRIPTION

* chore: use go-utils/errors for errors, make them not start by 'fail to', contextify everywhere for the errors
* feat(ensure-networks): Add API endpoint and CLI command to trigger it manually without restartng the service (19 minutes ago)
* feat(control-loop/ensure-networks): Add notion of control loop, ensure every 30 minutes (34 minutes ago)

